### PR TITLE
Update admin.php

### DIFF
--- a/lesson 27+28+29+30/routes/admin.php
+++ b/lesson 27+28+29+30/routes/admin.php
@@ -2,7 +2,7 @@
 
 Route::group(['prefix' => 'admin', 'namespace' => 'Admin'], function () {
 
-		Config::set('auth.defines', 'admin');
+		Config::set('auth.defines.guard', 'admin');
 		Route::get('login', 'AdminAuth@login');
 		Route::post('login', 'AdminAuth@dologin');
 		Route::get('forgot/password', 'AdminAuth@forgot_password');


### PR DESCRIPTION
		Config::set('auth.defines.guard', 'admin');
if u only put auth.defines insteed of puting gurad , it will change the array of deafults to only admin string which gonna throw error when u are traying to make a token in reset password cus ((Password resetter [] is not defined)) which comes from broker() function in passwordBrokerManger.php cus the $name of the driver is null .. that return us that auth.deafult is string and not array ..